### PR TITLE
docs: redis and admin warning

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,0 +1,3 @@
+### Important points to read before installing ⚠️
+
+- The first account created will be an admin user and will have all the admin rights. 👨‍💻

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -1,0 +1,3 @@
+### Points importants à lire avant l'installation ⚠️
+
+- Le premier compte créé sera un utilisateur administrateur et disposera de tous les droits d'administrateur. 👨‍💻

--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -4,4 +4,10 @@ A greatly enhanced fork of Misskey with better UI/UX, security, features, and mo
 
     Firefish is based off of Misskey, a powerful microblogging server on ActivityPub with features such as emoji reactions, a customizable web UI, rich chatting, and much more!
     Firefish adds many quality of life changes and bug fixes for users and instance admins alike.
-   
+
+### ⚠️ PLEASE READ CAREFULLY ⚠️
+
+**Firefish** requires **redis** version **7**, but YunoHost does not currently support this version.
+Some functions will not be available if you install this package.
+
+I advise you to wait for the release of _Bookworm_ Debian 12.

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -3,3 +3,10 @@ Un fork grandement amélioré de Misskey avec une meilleure UI/UX, sécurité, f
 
     Firefish est basé sur Misskey, un puissant serveur de microblogging sur ActivityPub avec des fonctionnalités telles que des réactions emoji, une interface web personnalisable, des discussions riches, et bien plus encore !
     Firefish ajoute de nombreux changements de qualité de vie et des corrections de bogues pour les utilisateurs et les administrateurs d'instance.
+
+### ⚠️ A LIRE ATTENTIVEMENT ⚠️
+
+Attention **Firefish** nécessite la version **7** de **redis** hors YunoHost ne permet pas actuellement de bénéficier de cette version.
+Certaines fonctions ne seront pas disponible si vous installez ce package.
+
+Je vous conseille d'attendre la sortie de _Bookworm_ Debian 12.


### PR DESCRIPTION
## Problem

**Firefish** requires **redis** version **7**, but YunoHost does not currently support this version. Some functions will not be available if you install this package.

The first account created will be an admin user and will have all the admin rights.

## Solution

Add redis and admin warning at README.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
